### PR TITLE
Issue #23: Use layout settings for block config, number field not text.

### DIFF
--- a/tagadelic.module
+++ b/tagadelic.module
@@ -451,15 +451,12 @@ function tagadelic_block_view($delta = '') {
 /**
  * Implements hook_block_configure().
  */
-function tagadelic_block_configure($delta = '') {
-  $voc = taxonomy_vocabulary_load($delta);
+function tagadelic_block_configure($delta = '', $settings = array()) {
   $form = array();
   $form['tags'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Tags to show'),
-    '#default_value' => config_get('tagadelic.settings', 'block_tags_' . $delta),
-    '#maxlength' => 3,
-    '#description' => t('The number of tags to show in this block.'),
+    '#type' => 'number',
+    '#title' => t('Number of tags to disply in this block.'),
+    '#default_value' => isset($settings['tags'])? $settings['tags'] : 12,
   );
   return $form;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/tagadelic/issues/23